### PR TITLE
Feature/decode sponsor logos

### DIFF
--- a/app/src/main/java/com/spartahack/spartahack17/Adapters/CompanyListAdapter.java
+++ b/app/src/main/java/com/spartahack/spartahack17/Adapters/CompanyListAdapter.java
@@ -1,6 +1,7 @@
 package com.spartahack.spartahack17.Adapters;
 
 import android.content.Context;
+import android.graphics.Bitmap;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -10,6 +11,7 @@ import android.widget.ImageView;
 import com.bumptech.glide.Glide;
 import com.spartahack.spartahack17.Model.Company;
 import com.spartahack.spartahack17.R;
+import com.spartahack.spartahack17.Utils.Base64Decoder;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -50,8 +52,7 @@ public class CompanyListAdapter extends RecyclerView.Adapter<CompanyListAdapter.
 
     public CompanyListAdapter(Context context, ArrayList<Company> data) {
         mContext = context;
-        if (data != null)
-            mData = data;
+        if (data != null) mData = data;
         else mData = new ArrayList<>();
     }
 
@@ -65,9 +66,9 @@ public class CompanyListAdapter extends RecyclerView.Adapter<CompanyListAdapter.
     @Override public void onBindViewHolder(SimpleViewHolder holder, final int position) {
         final Company c = mData.get(position);
 
-        if (c.getLogo_png_light()!= null){
-            // TODO: 1/6/17 fix this loading right 
-            Glide.with(mContext).load(c.getLogo_png_light()).into(holder.logo);
+        if (c.getLogo_png_light() != null){
+            Bitmap bitmap = Base64Decoder.decodeSampledBitmapFromBase64(c.getLogo_png_light(), 150, 150);
+            holder.logo.setImageBitmap(bitmap);
         } else {
             Glide.with(mContext).load(R.drawable.logo_17).into(holder.logo);
         }

--- a/app/src/main/java/com/spartahack/spartahack17/Presenter/CompanyPresenter.java
+++ b/app/src/main/java/com/spartahack/spartahack17/Presenter/CompanyPresenter.java
@@ -48,6 +48,6 @@ public class CompanyPresenter extends RxPresenter<CompanyView, ArrayList<Company
     @Override public int compare(Company lhs, Company rhs) {
         if (lhs.getLevel() != rhs.getLevel())
             return lhs.getLevel() - rhs.getLevel();
-        return rhs.getName().compareTo(lhs.getName());
+        return lhs.getName().compareTo(rhs.getName());
     }
 }

--- a/app/src/main/java/com/spartahack/spartahack17/Utils/Base64Decoder.java
+++ b/app/src/main/java/com/spartahack/spartahack17/Utils/Base64Decoder.java
@@ -12,7 +12,7 @@ import android.util.Base64;
 public class Base64Decoder {
 
     public static Bitmap decodeSampledBitmapFromBase64(String base64String,
-                                                        int reqWidth, int reqHeight) {
+                                                       int reqWidth, int reqHeight) {
 
         base64String = base64String.replace("data:image/png;base64,","");
         byte[] decodedString = Base64.decode(base64String, Base64.DEFAULT);

--- a/app/src/main/java/com/spartahack/spartahack17/Utils/Base64Decoder.java
+++ b/app/src/main/java/com/spartahack/spartahack17/Utils/Base64Decoder.java
@@ -1,0 +1,55 @@
+package com.spartahack.spartahack17.Utils;
+
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.util.Base64;
+
+/**
+ * Created by memuyskens on 1/11/17.
+ * SpartaHack-Android
+ */
+
+public class Base64Decoder {
+
+    public static Bitmap decodeSampledBitmapFromBase64(String base64String,
+                                                        int reqWidth, int reqHeight) {
+
+        base64String = base64String.replace("data:image/png;base64,","");
+        byte[] decodedString = Base64.decode(base64String, Base64.DEFAULT);
+
+        // First decode with inJustDecodeBounds=true to check dimensions
+        final BitmapFactory.Options options = new BitmapFactory.Options();
+        options.inJustDecodeBounds = true;
+        BitmapFactory.decodeByteArray(decodedString, 0, decodedString.length, options);
+
+        // Calculate inSampleSize
+        options.inSampleSize = calculateInSampleSize(options, reqWidth, reqHeight);
+
+        // Decode bitmap with inSampleSize set
+        options.inJustDecodeBounds = false;
+        return BitmapFactory.decodeByteArray(decodedString, 0, decodedString.length, options);
+    }
+
+    private static int calculateInSampleSize(BitmapFactory.Options options,
+                                             int reqWidth, int reqHeight) {
+        // Raw height and width of image
+        final int height = options.outHeight;
+        final int width = options.outWidth;
+        int inSampleSize = 1;
+
+        if (height > reqHeight || width > reqWidth) {
+
+            final int halfHeight = height / 2;
+            final int halfWidth = width / 2;
+
+            // Calculate the largest inSampleSize value that is a power of 2 and keeps both
+            // height and width larger than the requested height and width.
+            while ((halfHeight / inSampleSize) >= reqHeight
+                    && (halfWidth / inSampleSize) >= reqWidth) {
+                inSampleSize *= 2;
+            }
+        }
+
+        return inSampleSize;
+    }
+}

--- a/app/src/test/java/com/spartahack/spartahack17/Presenter/CompanyPresenterTest.java
+++ b/app/src/test/java/com/spartahack/spartahack17/Presenter/CompanyPresenterTest.java
@@ -63,7 +63,8 @@ public class CompanyPresenterTest extends BaseUnitTest {
         assertEquals(-1, presenter.compare(one, two));
         assertEquals(1, presenter.compare(three, two));
 
-        assertEquals(1, presenter.compare(four, three));
+        assertEquals(1, presenter.compare(three, four));
+        assertEquals(-1, presenter.compare(four, three));
 
         assertEquals(0, presenter.compare(five, four));
         assertEquals(0, presenter.compare(four, five));

--- a/app/src/test/java/com/spartahack/spartahack17/Presenter/ProfilePresenterTest.java
+++ b/app/src/test/java/com/spartahack/spartahack17/Presenter/ProfilePresenterTest.java
@@ -23,7 +23,7 @@ public class ProfilePresenterTest extends BaseUnitTest {
         presenter = new ProfilePresenter();
         presenter.attachView(view);
 
-        session = new Session();
+        session = new Session(0, "Sparty", "Spartan", "sparty@msu.edu", "", 0);
     }
 
     @Test public void onError() throws Exception {


### PR DESCRIPTION
The methods in the Base64Decoder class are based on what I found in the docs here:
https://developer.android.com/training/displaying-bitmaps/load-bitmap.html

Also note that sponsors were organized Z->A previously and I thought that was counterintuitive especially when I was comparing our sponsors to those on the website.